### PR TITLE
Update sequelize@4.0.0-1

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -51,12 +51,12 @@
     "mysql": "^2.11.1",
     "pg": "^6.1.0",
     "pre-commit": "^1.1.2",
-    "sequelize": "3.14.0",
+    "sequelize": "4.0.0-1",
     "should": "^11.0.0",
     "sqlite3": "^3.0.10"
   },
   "peerDependencies": {
-    "sequelize": ">=3.14.0"
+    "sequelize": ">=4.0.0-1"
   },
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
     "mysql": "^2.11.1",
     "pg": "^6.1.0",
     "pre-commit": "^1.1.2",
-    "sequelize": "3.14.0",
+    "sequelize": "4.0.0-1",
     "should": "^11.0.0",
     "sqlite3": "^3.0.10"
   },
   "peerDependencies": {
-    "sequelize": ">=3.14.0"
+    "sequelize": ">=4.0.0-1"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Resolves https://github.com/seegno/sequelize-sql-tag/issues/6.

This PR allows projects that use this package to upgrade to the latest major version of sequelize (v4). Without this, that upgrade would fail because of this package's requirement of a peer dependency wouldn't be met.
