### PR TITLE
Add security constraints to sequelize peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "sqlite3": "^3.0.10"
   },
   "peerDependencies": {
-    "sequelize": ">=3.14.0 || >=4.0.0-0"
+    "sequelize": ">= 3.35.1 || >= 4.44.4 || >=6.29.0"
   },
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,11 @@
   "peerDependencies": {
     "sequelize": ">= 3.35.1 || >= 4.44.4 || >=6.29.0"
   },
+  "peerDependenciesMeta": {
+    "sequelize": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=4"
   },


### PR DESCRIPTION
* Update `sequelize` peer dependency constraints to prevent version with known security exploits from being used.
* Mark `sequelize` peer dependency as optional via `peerDependenciesMeta` so it doesn't get installed (it's not required by this package).